### PR TITLE
release-v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.0.1 - 01-03-2023
+
+### Fixed
+
+- Fixed issue that, when using a regex, the prompt send to GPT was not vissible in the webview panel.
+- Fixed bug that the `selectedText` was given to the `getCompletionResult` function, but never used.
+- Removed timeout that extension did not load until VSCode was fully loaded.
+
+### Changes
+
+- Added a `Copy` button to the webview panel.
+- Render the original prompt as a `blockquote`.
+- Added some styling to the HTML webview panel.
+- Added the option to cancel the API request to OpenAI with a `cancel` button on the progress bar.
+
 ## 1.0.0 - 26-02-2023
 
 1.0.0 release of: `The Assistent`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "theassistent",
   "displayName": "TheAssistent",
   "description": "Interact with the OpenAI API directly from VSCode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icon": "logo.png",
   "publisher": "Jeroen",
   "license": "MIT",

--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -1,0 +1,47 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your extension and command.
+  * The sample plugin registers a command and defines its title and command name. With this information VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
+* `src/extension.ts` - this is the main file where you will provide the implementation of your command.
+  * The file exports one function, `activate`, which is called the very first time your extension is activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
+  * We pass the function containing the implementation of the command as the second parameter to `registerCommand`.
+
+## Setup
+
+* install the recommended extensions (amodio.tsl-problem-matcher and dbaeumer.vscode-eslint)
+
+
+## Get up and running straight away
+
+* Press `F5` to open a new window with your extension loaded.
+* Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
+* Set breakpoints in your code inside `src/extension.ts` to debug your extension.
+* Find output from your extension in the debug console.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+
+## Explore the API
+
+* You can open the full set of our API when you open the file `node_modules/@types/vscode/index.d.ts`.
+
+## Run tests
+
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
+* Press `F5` to run the tests in a new window with your extension loaded.
+* See the output of the test result in the debug console.
+* Make changes to `src/test/suite/extension.test.ts` or create new test files inside the `test/suite` folder.
+  * The provided test runner will only consider files matching the name pattern `**.test.ts`.
+  * You can create folders inside the `test` folder to structure your tests any way you want.
+
+## Go further
+
+* Reduce the extension size and improve the startup time by [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).
+* [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VS Code extension marketplace.
+* Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).


### PR DESCRIPTION
### Fixed

- Fixed issue that, when using a regex, the prompt send to GPT was not vissible in the webview panel.
- Fixed bug that the `selectedText` was given to the `getCompletionResult` function, but never used.
- Removed timeout that extension did not load until VSCode was fully loaded.

### Changes

- Added a `Copy` button to the webview panel.
- Render the original prompt as a `blockquote`.
- Added some styling to the HTML webview panel.
- Added the option to cancel the API request to OpenAI with a `cancel` button on the progress bar.